### PR TITLE
Fix RTREUSEWHERE in CREATEQUERY

### DIFF
--- a/source3/rpc_server/wsp/wsp_gss.c
+++ b/source3/rpc_server/wsp/wsp_gss.c
@@ -448,7 +448,11 @@ static void handle_createquery_done(struct tevent_req *subreq)
 		if (has_error == false) {
 			if(state->query_params_error) {
 				status = NT_STATUS(state->query_params_error);
+				DBG_DEBUG("copy error %s 0x%x from subrequest %p\n",
+					  nt_errstr(status), NT_STATUS_V(status), subreq);
 			} else {
+				DBG_DEBUG("can_query_now=false, returning"
+					  "NT_STATUS_INVALID_PARAMETER\n");
 				status = NT_STATUS_INVALID_PARAMETER;
 			}
 		}

--- a/source3/rpc_server/wsp/wsp_sparql_conv.c
+++ b/source3/rpc_server/wsp/wsp_sparql_conv.c
@@ -1613,6 +1613,11 @@ static const char* get_sort_string(TALLOC_CTX *ctx,
 	struct wsp_csort *order = sorting->sortarray;
 	const char* sort_str = NULL;
 	ZERO_STRUCT(sort_by);
+
+	if (sorting->count == 0) {
+		DBG_DEBUG("function called with a sorting->count of zero,"
+			  " returning NULL");
+	}
 	for (i = 0; i < sorting->count; i++) {
 		int pid_index = order[i].pidcolimn;
 		struct wsp_cfullpropspec *prop_spec =
@@ -1626,7 +1631,7 @@ static const char* get_sort_string(TALLOC_CTX *ctx,
 			int j;
 			if (order[i].dworder != QUERY_SORTASCEND &&
 				order[i].dworder != QUERY_DESCEND) {
-				DBG_ERR("Uknown sort order %d\n", order[i].dworder);
+				DBG_ERR("Unknown sort order %d\n", order[i].dworder);
 				return NULL;
 			}
 			if (sort_str == NULL) {
@@ -1734,6 +1739,7 @@ NTSTATUS build_tracker_query(TALLOC_CTX *ctx,
 	if (sorting) {
 		sort_str = get_sort_string(ctx, pidmapper, sorting);
 		if (sort_str == NULL) {
+			DBG_DEBUG("a SortSet was given, but no sort_str created\n");
 			return NT_STATUS_INVALID_PARAMETER;
 		}
 	}

--- a/source3/rpc_server/wsp/wsp_sparql_conv.c
+++ b/source3/rpc_server/wsp/wsp_sparql_conv.c
@@ -1543,15 +1543,17 @@ done:
 }
 
 static NTSTATUS rtreusewhere_to_string(TALLOC_CTX *ctx,
-					struct wsp_abstract_state *glob_data,
-					struct wsp_crestriction *restriction,
-					const char **result)
+				       struct wsp_abstract_state *glob_data,
+				       struct wsp_crestriction *restriction,
+				       void *priv_data,
+				       const char **result)
 {
-	int where_id;
-	const char *tmp;
 	NTSTATUS status;
-	*result = talloc_strdup(ctx, "");
-	where_id = restriction->restriction.reusewhere.whereid;
+	bool ok = false;
+	char *where_filter = NULL;
+	char *share_scope = NULL;
+	struct filter_data *data = (struct filter_data *) priv_data;
+	int where_id = restriction->restriction.reusewhere.whereid;
 	DBG_DEBUG("SHARE reusewhereid %d\n", where_id);
 	/*
 	* Try get a previously built whereid string,
@@ -1569,38 +1571,35 @@ static NTSTATUS rtreusewhere_to_string(TALLOC_CTX *ctx,
 	* is now 'released' thus we won't find the associated
 	* restriction set of that 'nested' whereid
 	*/
-	tmp = get_where_restriction_string(glob_data, where_id);
-	if (tmp && strlen(tmp)) {
-		*result = talloc_strdup(ctx, tmp);
-		DBG_NOTICE("detected a where id RTREUSEWHERE id=%d result = %s\n",
-		      restriction->restriction.reusewhere.whereid,
-		      tmp ? tmp : "None");
+	ok = lookup_where_id(glob_data, where_id, &where_filter, &share_scope);
+	if (ok && strlen(where_filter) && strlen(share_scope)) {
+		*result = talloc_strdup(ctx, where_filter);
+		data->where_id = where_id;
+		data->share_scope = talloc_strdup(ctx, share_scope);
+		DBG_NOTICE("detected a where id RTREUSEWHERE id=%d"
+			   " result = %s, share = %s\n",
+			   where_id, where_filter, share_scope);
 	} else {
 		/*
 		* this assumes the reason we have
 		* no whereid string is because there is no
 		* index, it's a pretty valid assumption
 		* but I think getting the status from
-		* maybe get_where_restriction_string might
-		* be better
+		* maybe lockup_where_id() might be better
 		*/
 		DBG_ERR("no whereid => this share is not indexed\n");
-		tmp = talloc_asprintf(ctx, "insert expression for WHEREID = %d",
-				      restriction->restriction.reusewhere.whereid);
+		*result = talloc_asprintf(ctx, "insert expression for"
+					  " WHEREID = %d", where_id);
 		/*
 		 * if glob_data == NULL then we are more than likely being
 		 * called from wsp_to_sparql and we don't want to propagate the
 		 * status for this case
 		 */
 		if (glob_data != NULL) {
-			status = NT_STATUS(0x80070003);
-			goto done;
+			return NT_STATUS(0x80070003);
 		}
 	}
-	status = NT_STATUS_OK;
-done:
-	*result = tmp;
-	return status;
+	return NT_STATUS_OK;
 }
 
 static const char* get_sort_string(TALLOC_CTX *ctx,
@@ -1851,17 +1850,11 @@ static NTSTATUS print_restriction(TALLOC_CTX *ctx,
 				break;
 			}
 			case RTREUSEWHERE: {
-				if (priv_data) {
-					struct filter_data *data =
-						(struct filter_data *)priv_data;
-					data->where_id =
-						restriction->restriction.reusewhere.whereid;
-				}
 				tmp = NULL;
-				status = rtreusewhere_to_string(ctx,
-							glob_data,
-							restriction,
-							&tmp);
+				status = rtreusewhere_to_string(ctx, glob_data,
+								restriction,
+								priv_data,
+								&tmp);
 				if (tmp && strlen(tmp)) {
 					result = tmp;
 				}

--- a/source3/rpc_server/wsp/wsp_sparql_conv.h
+++ b/source3/rpc_server/wsp/wsp_sparql_conv.h
@@ -77,7 +77,8 @@ NTSTATUS build_tracker_query(TALLOC_CTX *ctx,
 			     const char **query);
 
 
-const char * get_where_restriction_string(struct wsp_abstract_state *wsp_abstract_state, uint32_t id);
+bool lookup_where_id(struct wsp_abstract_state *glob_data, uint32_t where_id,
+		     const char **filter_out, const char **share_out);
 
 NTSTATUS build_restriction_expression(TALLOC_CTX *ctx,
 				      struct wsp_abstract_state *glob_data,

--- a/source3/rpc_server/wsp/wsp_srv_tracker-sparql.c
+++ b/source3/rpc_server/wsp/wsp_srv_tracker-sparql.c
@@ -287,7 +287,10 @@ cursor_cb(GObject *object, GAsyncResult *res, gpointer user_data)
 		query_info->num_cols =
 			tracker_sparql_cursor_get_n_columns(query_info->cur_cursor);
 	}
-	DEBUG(0,("more_results %d limit %d %d\n", more_results, query_info->results_limit, !(query_info->results_limit && query_info->num_rows >= query_info->results_limit)));
+	DBG_INFO("more_results %d limit %d %d\n", more_results,
+		 query_info->results_limit,
+		 !(query_info->results_limit &&
+		   query_info->num_rows >= query_info->results_limit));
 	if (more_results &&
 	    !(query_info->cache_results == false && query_info->results_limit &&
 	      query_info->num_rows >= query_info->results_limit)) {

--- a/source3/rpc_server/wsp/wsp_srv_tracker_abs_if.c
+++ b/source3/rpc_server/wsp/wsp_srv_tracker_abs_if.c
@@ -376,6 +376,7 @@ static struct tevent_req *run_new_query_send(TALLOC_CTX *ctx,
 	}
 
 	if (!share) {
+		DBG_ERR("No share passed in the RestrictionSet\n");
 		status = NT_STATUS_INVALID_PARAMETER;
 		can_query_now = false;
 		goto err_out;
@@ -417,6 +418,8 @@ static struct tevent_req *run_new_query_send(TALLOC_CTX *ctx,
 				     &sparql_query);
 
 	if (!NT_STATUS_IS_OK(status)) {
+		DBG_ERR("error %s when creating tracker query\n",
+		        nt_errstr(status));
 		can_query_now = false;
 		goto err_out;
 	}
@@ -440,6 +443,7 @@ static struct tevent_req *run_new_query_send(TALLOC_CTX *ctx,
 						p->session_info,
 						&query_info->tracker_ctx);
 		if (!subreq) {
+			DBG_ERR("failed to create tracker subquery\n");
 			can_query_now = false;
 			status = NT_STATUS_UNSUCCESSFUL;
 			goto err_out;

--- a/source3/rpc_server/wsp/wsp_srv_tracker_abs_if.c
+++ b/source3/rpc_server/wsp/wsp_srv_tracker_abs_if.c
@@ -205,8 +205,8 @@ static int destroy_query_data(struct query_data *query_info)
 	return 0;
 }
 
-const char * get_where_restriction_string(struct wsp_abstract_state *glob_data,
-					  uint32_t id)
+bool lookup_where_id(struct wsp_abstract_state *glob_data, uint32_t where_id,
+		     const char **filter_out, const char **share_out)
 {
 	/* search all open queries for where id */
 	struct query_data *item = NULL;
@@ -214,11 +214,14 @@ const char * get_where_restriction_string(struct wsp_abstract_state *glob_data,
 		item = glob_data->queries.items;
 	}
 	for (;item;item = item->next) {
-		if (item->query_id == id && item->where_filter) {
-			return item->where_filter;
+		if (item->query_id == where_id &&
+		    item->where_filter && item->share) {
+			*filter_out = item->where_filter;
+			*share_out = item->share;
+			return true;
 		}
 	}
-	return NULL;
+	return false;
 }
 
 static bool is_catalog_available(struct wspd_client_state *client_data,
@@ -345,17 +348,6 @@ static struct tevent_req *run_new_query_send(TALLOC_CTX *ctx,
 			*QueryParametersError = NT_STATUS_V(status);
 			can_query_now = false;
 			goto err_out;
-		}
-	}
-
-	if (!share) {
-		if (where_id) {
-			struct query_data *tmp_data =
-				find_query_info(where_id,
-						glob_data);
-			if (tmp_data) {
-				share = tmp_data->share;
-			}
 		}
 	}
 


### PR DESCRIPTION
First up: tremendous work!

While testing the WSP implementation with a Windows 8.1 I noticed an error in
the handling of the `RTREUSEWHERE` restriction. The code correctly identified
the case and called `rtreusewhere_to_string()`, but neither the `share` nor the
`where_id` where passed back, resulting in an error in `run_new_query_send()` as
the share was not set.

I believe with this, the [`find_query_info()`][0] in `run_new_query_send()` is
redundant, but I'm not quite sure.

I also added some more debug output to hunt that down.

[0]: https://github.com/noelpower/samba/blob/WSP-WIP/source3/rpc_server/wsp/wsp_srv_tracker_abs_if.c#L352-L359
